### PR TITLE
update django (5.2.7 -> 5.2.8)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django==5.2.7
+django==5.2.8
 django-debug-toolbar==6.0.0
 psycopg[binary]==3.2.10
 python-dateutil==2.9.0.post0


### PR DESCRIPTION
Changed requirements.txt (django update).

Dependabot alerts come from fixes in Django 5.2.8 release notes: https://docs.djangoproject.com/en/5.2/releases/5.2.8/